### PR TITLE
Import autocorr as float array

### DIFF
--- a/cngi/_utils/_table_conversion.py
+++ b/cngi/_utils/_table_conversion.py
@@ -205,7 +205,7 @@ def convert_simple_table(infile, outfile, subtable='', dimnames=None, timecols=[
 # timecols is a list of column names to convert to datetimes
 # dimnames is a dictionary mapping old to new dimension names for remaining dims (not in keys)
 # ignore is a list of column names to ignore
-def convert_expanded_table(infile, outfile, keys, subtable='', subsel=None, timecols=[], dimnames={}, ignore=[], compressor=None, chunks=(100, 20, 1), nofile=False):
+def convert_expanded_table(infile, outfile, keys, subtable='', subsel=None, timecols=[], dimnames={}, ignore=[], compressor=None, chunks=(100, 20, 1), nofile=False, extraselstr=''):
     
     if compressor is None:
         compressor = Blosc(cname='zstd', clevel=2, shuffle=0)
@@ -230,11 +230,16 @@ def convert_expanded_table(infile, outfile, keys, subtable='', subsel=None, time
     #  3. row_idxs = row numbers where each unique value occurs
     # then compute 1 and 3 for each additional key/dimension and store in midxs dictionary
     ordering = ','.join([np.atleast_1d(key)[ii] for key in keys.keys() for ii in range(len(np.atleast_1d(key)))])
-    if subsel is None:
+    if subsel is None or len(subsel) == 0:
+        selstr = str(extraselstr)
+    else:
+        selstr = '&&'.join([f'{k} = {v}' for k, v in subsel.items()])
+        if len(extraselstr) > 0:
+            selstr = f'({selstr}) && ({extraselstr})'
+    if len(selstr) == 0:
         sorted_table = tb_tool.taql('select * from %s ORDERBY %s' % (os.path.join(infile,subtable), ordering))
     else:
-        tsel = [list(subsel.keys())[0], list(subsel.values())[0]]
-        sorted_table = tb_tool.taql('select * from %s where %s = %s ORDERBY %s' % (os.path.join(infile,subtable), tsel[0], tsel[1], ordering))
+        sorted_table = tb_tool.taql('select * from %s where %s ORDERBY %s' % (os.path.join(infile,subtable), selstr, ordering))
         if sorted_table.nrows() == 0:
             sorted_table.close()
             tb_tool.close()

--- a/cngi/_utils/_table_conversion.py
+++ b/cngi/_utils/_table_conversion.py
@@ -291,6 +291,10 @@ def convert_expanded_table(infile, outfile, keys, subtable='', subsel=None, time
                                      for kk in np.arange(start_idx + 1, start_idx + len(data) + 1)])
                 else:
                     data = sorted_table.getcol(col, idx_range[0], len(idx_range)).transpose()
+                if np.iscomplexobj(data) is True and np.all(data.imag == 0):
+                    tmp = np.empty_like(data.real)
+                    tmp[:] = data.real
+                    data = tmp
             except Exception:
                 bad_cols += [col]
                 continue

--- a/cngi/_utils/_table_conversion.py
+++ b/cngi/_utils/_table_conversion.py
@@ -292,6 +292,7 @@ def convert_expanded_table(infile, outfile, keys, subtable='', subsel=None, time
                 else:
                     data = sorted_table.getcol(col, idx_range[0], len(idx_range)).transpose()
                 if np.iscomplexobj(data) is True and np.all(data.imag == 0):
+                    # generate C-contiguous float array from real part of complex data
                     tmp = np.empty_like(data.real)
                     tmp[:] = data.real
                     data = tmp


### PR DESCRIPTION
Fixes #5

convert_ms is updated to split autocorrelation data, which is essentially float array rather than complex array, into separate xds. Autocorrelation xds is named to "xdsaX" where X denotes the number corresponding to DATA_DESCRIPTION_ID (DDID), e.g. xdsa0, xdsa1, etc. Autocorrelation data are converted to float array if necessary. 

To do that, I made two updates to _table_conversion.convert_expanded_table. 

1. convert complex array into float array if all imaginary part is zero. resulting array is generated to be C-contiguous.
1. accept extra data selection string as a parameter, `extraselstr`

In convert_ms, two extra data selection strings are applied when convert_expanded_table is executed: the one to select autocorrelations and the other to exclude them. They are applied to each DDID so that each DDID produces two data chunks for autocorrelations and others. As a result number of xds in mxds will be (almost) doubled. 

I think this change is essential for efficient single dish data processing. Since this is my first pull request to CNGI, **I would like to ask reviewers to check the proposed changes very carefully. In particular, I suggest to check if the change has any negative impact on the interferometry data processing.** 