### PR TITLE
Fill with -1 instead of nan when dtype is integer

### DIFF
--- a/cngi/_utils/_table_conversion2.py
+++ b/cngi/_utils/_table_conversion2.py
@@ -97,8 +97,11 @@ def read_simple_table(infile, subtable='', timecols=None, ignore=None, add_row_i
             # sometimes the columns are variable, so we need to standardize to the largest sizes
             if len(np.unique([isinstance(rr[col], dict) for rr in tr])) > 1: continue   # can't deal with this case
             mshape = np.array(np.max([np.array(rr[col]).shape for rr in tr], axis=0))
+            const_val = np.nan
+            if isinstance(tr[0][col], np.ndarray) and np.issubdtype(tr[0][col].dtype, np.integer):
+                const_val = -1
             data = np.stack([np.pad(rr[col] if len(rr[col]) > 0 else np.array(rr[col]).reshape(np.arange(len(mshape))*0),
-                                    [(0, ss) for ss in mshape - np.array(rr[col]).shape], 'constant', constant_values=np.nan) for rr in tr])
+                                    [(0, ss) for ss in mshape - np.array(rr[col]).shape], 'constant', constant_values=const_val) for rr in tr])
 
         if len(data) == 0: continue
         if col in timecols: convert_time(data)


### PR DESCRIPTION
Hi! While learning about the prototype, I encountered an error when running the Data Structures Colab [notebook](https://colab.research.google.com/github/casangi/cngi_prototype/blob/master/docs/data_structures.ipynb):
<img width="360" alt="image" src="https://user-images.githubusercontent.com/21100851/192106145-89672f51-cd23-479e-a755-4a6432410f15.png">

The error comes from the following line:
https://github.com/casangi/cngi_prototype/blob/920580a3c92b8c20c548e47208a384944b322e93/cngi/_utils/_table_conversion2.py#L365
Specifically, because `assoc_spw_id` has a dtype of integer, it is impossible to fill it with `np.nan`.

I am not very familiar with the context of these data, but a quick fix would be to fill it with, say, `-1` (in this PR), or to simply convert the dtype into float.
